### PR TITLE
[PM-2850] Remove team leads from CODEOWNERS file and replace with cli…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default file owners.
-* @bitwarden/team-leads-eng
+* @bitwarden/team-client-integrations-dev
 
 # DevOps for Actions and other workflow changes.
 .github/workflows @bitwarden/dept-devops


### PR DESCRIPTION
…ent-itegrations-dev team

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2850

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🎂 Other

## 📔 Objective

Removing `@bitwarden/team-leads-eng` as a required reviewer within the CODEOWNERS file and replacing that with `@bitwarden/team-client-itegrations-dev` as the primary owner of the repository's source code. This change was requested by @djsmith85 to lessen the spam that was being generated for members of the team-leads-eng group.

## 📋 Code changes

-   **.github/CODEOWNERS:** Updating this file to remove team leads as a required reviewer for changes to the source code structure, and replaced the required reviewers with the client-integrations team.
