### PR TITLE
Correct var name

### DIFF
--- a/scripts/cli-serve-helper.sh
+++ b/scripts/cli-serve-helper.sh
@@ -10,6 +10,8 @@ set +o allexport
 export NODE_EXTRA_CA_CERTS=$ROOT_DIR/$BW_SSL_CERT
 
 export BITWARDENCLI_APPDATA_DIR="$ROOT_DIR/vault-seeder/tmp"
+# BITWARDENCLI_APPDATA_DIR is a special var. See:
+# https://github.com/bitwarden/clients/blob/1a6573ba96613ebcfd19c1c90ee5523452b8903a/apps/cli/src/bw.ts#L149
 mkdir -p "$BITWARDENCLI_APPDATA_DIR"
 
 BW_COMMAND() {


### PR DESCRIPTION
`BITWARDENCLI_APPDATA_DIR` is a special var that needs to be named that way in order for the `bw` CLI to use a custom data dir: https://bitwarden.com/help/cli/#log-in-to-multiple-accounts

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

Changing `CLI_APPDATA_DIR` -> `BITWARDENCLI_APPDATA_DIR` makes it so the script does not use the default app data dir and overwrite your system's config.

## 📋 Code changes

-   **`scripts/cli-serve-helper.sh`:** Description of what was changed and why.