### PR TITLE
[PM-6220] Bugfix - Pin the bitwarden self-host image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - db
     env_file:
       - .env
-    image: bitwarden/self-host:beta # https://bitwarden.com/help/install-and-deploy-unified-beta/
+    image: bitwarden/self-host:2024.1.2-beta # https://github.com/bitwarden/self-host/releases/tag/v2024.1.2
     restart: always
     ports:
       - ${VAULT_HOST_PORT}:8443


### PR DESCRIPTION
Looks like there’s an issue with the latest version of Bitwarden Unified (or our configuration around it) which is manifesting as the account creation script being unable to reach the server.

With this PR, we pin the version of the docker image instead of grabbing the latest beta (which resolves the issue)


Example of account creation hang:
https://github.com/bitwarden/browser-interactions-testing/actions/runs/7835123975