### PR TITLE
[PM-6311] Bugfix - Do not abandon clients browser artifact download if the target build workflow failed overall

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,7 +6,7 @@ on:
       CLIENTS_BRANCH:
         required: true
         default: "main"
-        description: "clients branch or commit hash of extensions build to use"
+        description: "clients branch of browser build to use"
         type: string
       FEATURE_FLAGS:
         required: true
@@ -37,7 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
-          workflow_conclusion: success
+          workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
           name: ^dist-chrome-(?!MV3-)\w{7}\.zip$
           name_is_regexp: true

--- a/.github/workflows/test-autofill.yml
+++ b/.github/workflows/test-autofill.yml
@@ -6,7 +6,7 @@ on:
       CLIENTS_BRANCH:
         required: true
         default: "main"
-        description: "clients branch or commit hash of extensions build to use"
+        description: "clients branch of browser build to use"
         type: string
       FEATURE_FLAGS:
         required: true
@@ -37,7 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
-          workflow_conclusion: success
+          workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
           name: ^dist-chrome-(?!MV3-)\w{7}\.zip$
           name_is_regexp: true

--- a/.github/workflows/test-notification.yml
+++ b/.github/workflows/test-notification.yml
@@ -6,7 +6,7 @@ on:
       CLIENTS_BRANCH:
         required: true
         default: "main"
-        description: "clients branch or commit hash of extensions build to use"
+        description: "clients branch of browser build to use"
         type: string
       FEATURE_FLAGS:
         required: true
@@ -37,7 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
-          workflow_conclusion: success
+          workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
           name: ^dist-chrome-(?!MV3-)\w{7}\.zip$
           name_is_regexp: true

--- a/.github/workflows/test-overlay-autofill.yml
+++ b/.github/workflows/test-overlay-autofill.yml
@@ -6,7 +6,7 @@ on:
       CLIENTS_BRANCH:
         required: true
         default: "main"
-        description: "clients branch or commit hash of extensions build to use"
+        description: "clients branch of browser build to use"
         type: string
       FEATURE_FLAGS:
         required: true
@@ -37,7 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
-          workflow_conclusion: success
+          workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
           name: ^dist-chrome-(?!MV3-)\w{7}\.zip$
           name_is_regexp: true


### PR DESCRIPTION
When the BIT test workflows have attempted to download chrome browser build artifacts from PRs with failed safari browser builds, the BIT test workflow fails.

adjusting `action-download-artifacts` `workflow_conclusion: success` to `workflow_conclusion: ""` allows the workflow to use the chrome browser build artifact even if the workflow of the target PR failed (in this case, elsewhere)