### PR TITLE
Adjust renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,11 +17,6 @@
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "groupName": "npm minor",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
For now, we want to separate out the npm package version bumps