### PR TITLE
[PM-7876] Update workflows to fetch test-site publicly

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -88,11 +88,24 @@ jobs:
       - name: Setup the vault test account ciphers
         run: npm run seed:vault:ciphers:ci
 
-      - name: Setup test site
+      - name: Download test site build
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          workflow_conclusion: ""
+          branch: main
+          name: build-files
+          path: test-site
+          repo: bitwarden/test-the-web
+          if_no_artifact_found: fail
+
+      - name: Copy over certs and install test site dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}'
-          npm run setup:test-site
+          cp ssl.crt test-site/api/
+          cp ssl.key test-site/api/
+          cd test-site
+          npm ci
 
       - name: Run all tests
         run: npm run test:static:ci

--- a/.github/workflows/test-autofill.yml
+++ b/.github/workflows/test-autofill.yml
@@ -84,11 +84,24 @@ jobs:
       - name: Setup the vault test account ciphers
         run: npm run seed:vault:ciphers:ci
 
-      - name: Setup test site
+      - name: Download test site build
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          workflow_conclusion: ""
+          branch: main
+          name: build-files
+          path: test-site
+          repo: bitwarden/test-the-web
+          if_no_artifact_found: fail
+
+      - name: Copy over certs and install test site dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}'
-          npm run setup:test-site
+          cp ssl.crt test-site/api/
+          cp ssl.key test-site/api/
+          cd test-site
+          npm ci
 
       - name: Run autofill tests
         run: npm run test:static:autofill:ci

--- a/.github/workflows/test-notification.yml
+++ b/.github/workflows/test-notification.yml
@@ -84,11 +84,24 @@ jobs:
       - name: Setup the vault test account ciphers
         run: npm run seed:vault:ciphers:ci
 
-      - name: Setup test site
+      - name: Download test site build
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          workflow_conclusion: ""
+          branch: main
+          name: build-files
+          path: test-site
+          repo: bitwarden/test-the-web
+          if_no_artifact_found: fail
+
+      - name: Copy over certs and install test site dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}'
-          npm run setup:test-site
+          cp ssl.crt test-site/api/
+          cp ssl.key test-site/api/
+          cd test-site
+          npm ci
 
       - name: Run notification tests
         run: npm run test:static:notification:ci

--- a/.github/workflows/test-overlay-autofill.yml
+++ b/.github/workflows/test-overlay-autofill.yml
@@ -84,11 +84,24 @@ jobs:
       - name: Setup the vault test account ciphers
         run: npm run seed:vault:ciphers:ci
 
-      - name: Setup test site
+      - name: Download test site build
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yml
+          workflow_conclusion: ""
+          branch: main
+          name: build-files
+          path: test-site
+          repo: bitwarden/test-the-web
+          if_no_artifact_found: fail
+
+      - name: Copy over certs and install test site dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}'
-          npm run setup:test-site
+          cp ssl.crt test-site/api/
+          cp ssl.key test-site/api/
+          cd test-site
+          npm ci
 
       - name: Run inline-menu tests
         run: npm run test:static:inline-menu:ci


### PR DESCRIPTION
## 🎟️ Tracking

PM-7876

## 📔 Objective

Now that test-the-web is public, we no longer need to utilize deploy keys to fetch the project repo

## ⚠️ NOTE

- [X] ~https://github.com/bitwarden/test-the-web/pull/133 must be merged before this PR will pass BIT tests successfully~

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
