### PR TITLE
[PM-8001] Update tests to use new location of vault timeout setting

### DIFF
--- a/tests/notification-bar.spec.ts
+++ b/tests/notification-bar.spec.ts
@@ -24,7 +24,7 @@ test.describe("Extension triggers a notification bar when a page form is submitt
 
     // Needed to allow the background reload further down
     await test.step("Set vault to never timeout", async () => {
-      const extensionAutofillSettingsURL = `chrome-extension://${extensionId}/popup/index.html?uilocation=popout#/tabs/settings`;
+      const extensionAutofillSettingsURL = `chrome-extension://${extensionId}/popup/index.html?uilocation=popout#/account-security`;
       await testPage.goto(extensionAutofillSettingsURL, defaultGotoOptions);
       await testPage
         .getByLabel("Vault timeout", { exact: true })


### PR DESCRIPTION
## 🎟️ Tracking

PM-8001

## 📔 Objective

Notification tests break on main because they are unable to set the vault timeout setting

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
