### PR TITLE
[PM-8105] Bug - Update vault timeout option selection of "never"

### DIFF
--- a/tests/notification-bar.spec.ts
+++ b/tests/notification-bar.spec.ts
@@ -28,7 +28,7 @@ test.describe("Extension triggers a notification bar when a page form is submitt
       await testPage.goto(extensionAutofillSettingsURL, defaultGotoOptions);
       await testPage
         .getByLabel("Vault timeout", { exact: true })
-        .selectOption("9: null");
+        .selectOption("9: never");
       await testPage.getByRole("button", { name: "Yes" }).click();
     });
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-8105

## 📔 Objective

BIT notification bar test was broken by https://github.com/bitwarden/clients/pull/8604

When setting the vault timeout value, the test was trying to select "9: null", but that's now "9: never" - this PR updates that.

Additionally, the test expects a pop up so it can click "Yes":

![Screenshot 2024-05-13 at 4 29 32 PM](https://github.com/bitwarden/browser-interactions-testing/assets/1556494/865bf0a3-e110-4c26-88f5-57dc55295d33)

^ the pop up no longer appears (broken by https://github.com/bitwarden/clients/pull/8604), but will be fixed by https://github.com/bitwarden/clients/pull/9164 - until then, the notification tests will break, even after this PR merge, until https://github.com/bitwarden/clients/pull/9164 is also in.

@JaredSnider-Bitwarden added as an optional reviewer for visibility

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
