### PR TITLE
[PM-8890] Remove the option to test MV2 build artifacts in Github workflows

### DIFF
--- a/.github/workflows/a11y-eval-all.yml
+++ b/.github/workflows/a11y-eval-all.yml
@@ -1,13 +1,8 @@
 name: All-a11y-evaluation
-run-name: All a11y evaluations with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: All a11y evaluations with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -47,7 +42,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/.github/workflows/a11y-eval-browser.yml
+++ b/.github/workflows/a11y-eval-browser.yml
@@ -1,13 +1,8 @@
 name: Browser-client-a11y-evaluation
-run-name: Browser client a11y evaluation with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: Browser client a11y evaluation with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -47,7 +42,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,5 +1,5 @@
 name: Test-all
-run-name: All tests with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   push:
     branches:
@@ -7,11 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -51,7 +46,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH || 'main' }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/.github/workflows/test-autofill.yml
+++ b/.github/workflows/test-autofill.yml
@@ -1,13 +1,8 @@
 name: Test-autofill
-run-name: Autofill tests with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: Autofill tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -47,7 +42,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/.github/workflows/test-notification.yml
+++ b/.github/workflows/test-notification.yml
@@ -1,13 +1,8 @@
 name: Test-notification
-run-name: Notification tests with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: Notification tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -47,7 +42,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/.github/workflows/test-overlay-autofill.yml
+++ b/.github/workflows/test-overlay-autofill.yml
@@ -1,13 +1,8 @@
 name: Test-inline-menu
-run-name: Inline menu tests with MV${{ inputs.TEST_MV2 == true && 2 || 3 }} extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: Inline menu tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
-      TEST_MV2:
-        default: false
-        description: "test with the manifest version 2 extension build"
-        required: false
-        type: boolean
       CLIENTS_BRANCH:
         default: "main"
         description: "clients branch of browser build to use"
@@ -47,7 +42,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: ""
           branch: ${{ inputs.CLIENTS_BRANCH }}
-          name: ${{ inputs.TEST_MV2 == true && '^dist-chrome-\w{7}\.zip$' || 'dist-chrome-MV3-\w{7}\.zip' }}
+          name: dist-chrome-MV3-\w{7}\.zip
           name_is_regexp: true
           repo: bitwarden/clients
           if_no_artifact_found: fail

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Create and start the containers and volumes with `docker compose up -d --build -
 - Run headless testing with `npm run test:static:headless`
 - Run headed tests in debug mode with `npm run test:static:debug`
 - Run only the public pages testing with `npm run test:public:debug`
-- Testing builds and uses the Manifest v3 version of the browser client by default; the v2 version can be build with `npm run build:extension:v2`
+- Test builds use the Manifest v3 version of the browser client by default; the v2 version can be built with `npm run build:extension:v2`
 
 ## Feature flags
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-8890

## 📔 Objective

Since we no longer publish the Manifest version 2 build of the Chromium browser client (and we don't support testing on other browsers for the moment), we'll want to drop it from automation workflows since there are not longer targetable build artifacts.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
