### PR TITLE
[PM-12239] use repo secret for installation keys instead of generating them on-the-fly

### DIFF
--- a/.github/workflows/a11y-eval-all.yml
+++ b/.github/workflows/a11y-eval-all.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -69,9 +71,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/a11y-eval-browser.yml
+++ b/.github/workflows/a11y-eval-browser.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -69,9 +71,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/a11y-eval-web.yml
+++ b/.github/workflows/a11y-eval-web.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -47,9 +49,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS || '{}' }}}" > flags.json
@@ -73,9 +75,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/test-autofill.yml
+++ b/.github/workflows/test-autofill.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -69,9 +71,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/test-notification.yml
+++ b/.github/workflows/test-notification.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -69,9 +71,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60

--- a/.github/workflows/test-overlay-autofill.yml
+++ b/.github/workflows/test-overlay-autofill.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo setcap 'cap_net_bind_service=+ep' `which node`
           echo "${{ secrets.ENV_FILE }}" | base64 --decode > .env
+          echo "BW_INSTALLATION_ID=${{ secrets.BW_INSTALLATION_ID }}" >> .env
+          echo "BW_INSTALLATION_KEY=${{ secrets.BW_INSTALLATION_KEY }}" >> .env
 
       - name: Create feature flags file
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS }}}" > flags.json
@@ -69,9 +71,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-
-      - name: Generate and install keys
-        run: npm run setup:install
 
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12239]

## 📔 Objective

Instead of running the install keys generate script in the Github action workflows, we should use static values stored in the repo secrets

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-12239]: https://bitwarden.atlassian.net/browse/PM-12239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ