### PR TITLE
[deps] PM-12888 - Bump libnss3-tools version

### DIFF
--- a/.github/workflows/a11y-eval-all.yml
+++ b/.github/workflows/a11y-eval-all.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -58,7 +58,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/a11y-eval-browser.yml
+++ b/.github/workflows/a11y-eval-browser.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -58,7 +58,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/a11y-eval-web.yml
+++ b/.github/workflows/a11y-eval-web.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -36,7 +36,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -62,7 +62,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/test-autofill.yml
+++ b/.github/workflows/test-autofill.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -58,7 +58,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/test-notification.yml
+++ b/.github/workflows/test-notification.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -58,7 +58,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password

--- a/.github/workflows/test-overlay-autofill.yml
+++ b/.github/workflows/test-overlay-autofill.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -58,7 +58,7 @@ jobs:
       - name: Generate and install certs
         run: |
           npm run setup:ssl
-          sudo apt-get install libnss3-tools=2:3.68.2-0ubuntu1
+          sudo apt-get install libnss3-tools=2:3.98-1build1
           . .env
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N --empty-password


### PR DESCRIPTION
## 🎟️ Tracking

PM-12888

## 📔 Objective

Github test runners for Ubuntu 24 are now available, but cannot be used for the workflows in this project as we're using a pinned version of `libnss3-tools` that is not available on Ubuntu 24. Note, `libnss3-tools` was pinned due to [newer versions breaking the cert generation script](https://github.com/bitwarden/browser-interactions-testing/pull/143).

This resolves https://github.com/bitwarden/browser-interactions-testing/pull/246 as well as PM-12888

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
