### PR TITLE
[PM-17406] Skip broken test cases

### DIFF
--- a/constants/test-pages.ts
+++ b/constants/test-pages.ts
@@ -123,6 +123,8 @@ export const testPages: PageTest[] = [
       },
     },
     skipTests: [
+      TestNames.MessageAutofill, // @TODO known failure - fails to autofill (PM-17393)
+      TestNames.InlineMenuAutofill, // @TODO known failure - inline menu does not appear (PM-17393)
       TestNames.NewCredentialsNotification, // @TODO known failure - save prompt does not appear (PM-8697)
       TestNames.PasswordUpdateNotification, // @TODO known failure - update prompt does not appear (PM-8697)
     ],
@@ -189,6 +191,8 @@ export const testPages: PageTest[] = [
       password: { selector: "#password", value: "fakeMultiStepPassword" },
     },
     skipTests: [
+      TestNames.MessageAutofill, // @TODO known failure - fails to autofill (PM-17393)
+      TestNames.InlineMenuAutofill, // @TODO known failure - inline menu does not appear (PM-17393)
       TestNames.NewCredentialsNotification, // @TODO known failure - save prompt does not appear (PM-8697)
       TestNames.PasswordUpdateNotification, // @TODO known failure - update prompt does not appear (PM-8697)
     ],


### PR DESCRIPTION
## 🎟️ Tracking

PM-17406

## 📔 Objective

Two test cases were broken by the changes in https://github.com/bitwarden/clients/pull/12695

In both of the below cases, form autofill and the appearance of the inline menu have stopped working (where they had previously):
https://webtests.dev/forms/login/multi-step-login/
https://webtests.dev/forms/login/hidden-login/

Disabling these cases in testing will allow the continued use of BIT while we determine remediation ([PM-17393](https://bitwarden.atlassian.net/browse/PM-17393))

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-17393]: https://bitwarden.atlassian.net/browse/PM-17393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ