### PR TITLE
[PM-17393] Revert "skip broken test cases (#302)"

### DIFF
--- a/constants/test-pages.ts
+++ b/constants/test-pages.ts
@@ -123,8 +123,6 @@ export const testPages: PageTest[] = [
       },
     },
     skipTests: [
-      TestNames.MessageAutofill, // @TODO known failure - fails to autofill (PM-17393)
-      TestNames.InlineMenuAutofill, // @TODO known failure - inline menu does not appear (PM-17393)
       TestNames.NewCredentialsNotification, // @TODO known failure - save prompt does not appear (PM-8697)
       TestNames.PasswordUpdateNotification, // @TODO known failure - update prompt does not appear (PM-8697)
     ],
@@ -191,8 +189,6 @@ export const testPages: PageTest[] = [
       password: { selector: "#password", value: "fakeMultiStepPassword" },
     },
     skipTests: [
-      TestNames.MessageAutofill, // @TODO known failure - fails to autofill (PM-17393)
-      TestNames.InlineMenuAutofill, // @TODO known failure - inline menu does not appear (PM-17393)
       TestNames.NewCredentialsNotification, // @TODO known failure - save prompt does not appear (PM-8697)
       TestNames.PasswordUpdateNotification, // @TODO known failure - update prompt does not appear (PM-8697)
     ],


### PR DESCRIPTION
This reverts commit ba01ac6fbc9d1a027255a480f2ea4810fe98774b.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17393

## 📔 Objective

No longer need to skip the known failures since https://github.com/bitwarden/clients/pull/13018

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
