### PR TITLE
[PM-18317] Wait for form submit redirect on notification bar tests

### DIFF
--- a/tests/static/notification-bar.spec.ts
+++ b/tests/static/notification-bar.spec.ts
@@ -149,6 +149,9 @@ test.describe("Extension triggers a notification bar when a page form is submitt
             await testPage.keyboard.press("Enter");
           }
 
+          // Wait for form submit redirect
+          await testPage.waitForLoadState();
+
           await testPage.screenshot({
             fullPage: true,
             path: path.join(
@@ -264,6 +267,9 @@ test.describe("Extension triggers a notification bar when a page form is submitt
           } else {
             await testPage.keyboard.press("Enter");
           }
+
+          // Wait for form submit redirect
+          await testPage.waitForLoadState();
 
           await testPage.screenshot({
             fullPage: true,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18317

## 📔 Objective

Fixes some notification bar test failures do to timing side-effects of https://github.com/bitwarden/clients/pull/13395

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
