### PR TITLE
[PM-18585] Handle duplicate notification bars and verify notification dismissal

### DIFF
--- a/tests/static/notification-bar.spec.ts
+++ b/tests/static/notification-bar.spec.ts
@@ -160,9 +160,10 @@ test.describe("Extension triggers a notification bar when a page form is submitt
             ),
           });
 
-          const notificationBarLocator = await testPage.frameLocator(
-            "#bit-notification-bar-iframe",
-          );
+          const notificationBarLocator = await testPage
+            .locator("#bit-notification-bar-iframe")
+            .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
+            .contentFrame();
 
           const newCipherNotificationBarLocator =
             notificationBarLocator.getByText(
@@ -285,9 +286,10 @@ test.describe("Extension triggers a notification bar when a page form is submitt
             ),
           });
 
-          const notificationBarLocator = await testPage.frameLocator(
-            "#bit-notification-bar-iframe",
-          );
+          const notificationBarLocator = await testPage
+            .locator("#bit-notification-bar-iframe")
+            .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
+            .contentFrame();
 
           const updatePasswordNotificationBarLocator =
             notificationBarLocator.getByText(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18585](https://bitwarden.atlassian.net/browse/PM-18585)

## 📔 Objective

The notification tests are still (usually) failing on the appearance of two notification bars (in BIT testing only, and so far, only for the original notification experience). This PR aims to fix that.

Additionally, the notification tests should confirm that the notification should be dismissible.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-18585]: https://bitwarden.atlassian.net/browse/PM-18585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ