### PR TITLE
[PM-21373] Update bitwarden/self-host image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
+name: v2025.4.1
 services:
   bitwarden:
     depends_on:
       - db
     env_file:
       - .env
-    image: bitwarden/self-host:2025.2.1-beta # https://github.com/bitwarden/self-host/releases
+    image: ghcr.io/bitwarden/self-host:2025.4.1-beta # https://github.com/bitwarden/self-host/releases
     restart: always
     ports:
       - ${VAULT_HOST_PORT}:8443


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21373](https://bitwarden.atlassian.net/browse/PM-21373)

## 📔 Objective

We stopped getting regular automated version checks on the Bitwarden Unified image used to stand up server/web backing BIT tests. This is due to [the registry switch over to GHCR](https://github.com/bitwarden/self-host/releases/tag/v2025.3.0) for version `2025.3.0` and later, so `2025.2.1` was being seen as the latest version at the old registry location

This consequently prevented latest prod feature flags from being supported and tests against BIT

Note: we're moving to `v2025.4.1` for now since the account creation endpoint fails with our current script on `v2025.4.2` (will be investigated in [PM-21380](https://bitwarden.atlassian.net/browse/PM-21380))

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-21373]: https://bitwarden.atlassian.net/browse/PM-21373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-21380]: https://bitwarden.atlassian.net/browse/PM-21380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ