### PR TITLE
[PM-21380] Remove check for old email presence error

### DIFF
--- a/scripts/create-account.ts
+++ b/scripts/create-account.ts
@@ -113,26 +113,6 @@ async function createAccount() {
       emitSuccessMessage(vaultHost);
       return;
     }
-
-    let emailIsTaken = false;
-
-    const responseErrors =
-      Object.values(responseData?.validationErrors || {})[0] || [];
-
-    for (let error of responseErrors) {
-      if (emailIsTaken) {
-        break;
-      }
-
-      emailIsTaken = !!error.match(/^Email \'.*\' is already taken\.$/g)
-        ?.length;
-    }
-
-    if (emailIsTaken) {
-      emitSuccessMessage(vaultHost);
-
-      return;
-    }
   } catch (error) {
     // Server isn't ready yet
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21380](https://bitwarden.atlassian.net/browse/PM-21380)

## 📔 Objective

Follow on from https://github.com/bitwarden/browser-interactions-testing/pull/341 - the `"Email {email} is already taken"` error appears to no longer be a validationError and is now returned as the message of an error object in response to the first registration POST request https://github.com/search?q=repo%3Abitwarden%2Fserver+%22is+already+taken%22&type=code

The case shouldn't be reachable for the second call in any case, since we exit early after the first call with this case.

Consequently, I've removed the handling for the email presence case on the second registration POST request.

[PM-21380]: https://bitwarden.atlassian.net/browse/PM-21380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ