### PR TITLE
[PM-22791] Bump Bitwarden CLI version used by the setup scripts

### DIFF
--- a/scripts/first-time-setup.sh
+++ b/scripts/first-time-setup.sh
@@ -2,7 +2,7 @@
 
 npm run setup:ssl
 
-npm install -g @bitwarden/cli@2025.1.0
+npm install -g @bitwarden/cli@2025.4.0
 npm ci
 npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22791](https://bitwarden.atlassian.net/browse/PM-22791)

## 📔 Objective

Bump Bitwarden CLI version used by the setup scripts to `v2025.4.0` (`v2025.5.0` doesn't install)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-22791]: https://bitwarden.atlassian.net/browse/PM-22791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ