### PR TITLE
[PM-22295] Do not include public sites in mock cipher generation unless env variable is active

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ VAULT_HOST_URL="https://localhost"
 # Used to match a remote server configuration.
 REMOTE_VAULT_CONFIG_MATCH="https://localhost:8443/api/config"
 
+# (Optional) Indicate whether mock ciphers used in live site tests should be included in vault seeding
+# INCLUDE_PUBLIC_PAGE_CIPHERS="true"
+
 # (Optional) Specify the root directory filename for the Bitwarden vault JSON import
 # you'd like to use (e.g. "vault.json")
 # Mock data generation tool: https://www.passwordvaultgenerator.com/

--- a/scripts/vault-seeder.ts
+++ b/scripts/vault-seeder.ts
@@ -68,7 +68,13 @@ class VaultSeeder {
       vaultItems.forEach((item) => (existingVaultItems[item.name] = item));
     }
 
-    const allCiphers = [...localPageCiphers, ...publicPageCiphers];
+    const includePublicPageCiphers =
+      process.env.INCLUDE_PUBLIC_PAGE_CIPHERS === "true";
+
+    const allCiphers = [
+      ...localPageCiphers,
+      ...(includePublicPageCiphers ? publicPageCiphers : []),
+    ];
 
     for (let index = 0; index < allCiphers.length; index++) {
       const pageCipher = allCiphers[index];


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22295](https://bitwarden.atlassian.net/browse/PM-22295)

## 📔 Objective

We don't need the public site mock ciphers generated in the test vault for most test cases, so skip them unless the user has specified otherwise in their `.env` config. This will also slightly improve the speed of action workflow execution.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-22295]: https://bitwarden.atlassian.net/browse/PM-22295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ