### PR TITLE
[PM-5756] Comment on originating PR with BIT results

### DIFF
--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -180,7 +180,7 @@ jobs:
       # typical config case covered for success feedback
       - name: Communicate BIT failure on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: failure() && github.event.client_payload.origin_issue
+        if: failure() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -74,7 +74,7 @@ jobs:
           branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
-          repo: bitwarden/clients
+          repo: jprusik/clients
           if_no_artifact_found: fail
           skip_unpack: true
 
@@ -158,15 +158,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = 'bitwarden';
+            const featureFlags = ${{ inputs.FEATURE_FLAGS }};
+            const runURL = `https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}`;
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with ${{ inputs.FEATURE_FLAGS === '{}' ? 'all feature flags disabled.': '\n\n<details><summary><div>The following flags enabled:</div></summary>```json\n${{inputs.FEATURE_FLAGS}}```'}
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with ${ featureFlags === '{}' ? 'all feature flags disabled.': '\n\n<details><summary><div>The following flags enabled:</div></summary>\`\`\`json\n${ featureFlags }\`\`\`'}}
 
             ❌ Unfortunately, one or more of these BIT tests failed. 😞
 
-            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you'd like help.
+            Please resolve the failure before merging- reach out to \`@bitwarden/team-autofill-dev\` if you'd like help.
 
-            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+            You can view the detailed results of the tests [here](${runURL}).`;
 
             github.rest.issues.createComment({
               issue_number: context.payload.client_payload.origin_issue,

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -1,9 +1,11 @@
 name: Test-all-custom-flags
-run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH || github.event.client_payload.origin_branch }} by @${{ github.actor }}
 on:
   push:
     branches:
       - "main"
+  repository_dispatch:
+    types: [trigger-bit-tests]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -25,6 +27,7 @@ jobs:
       id-token: write
       contents: read
       packages: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -68,7 +71,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
           workflow_conclusion: ""
-          branch: ${{ inputs.CLIENTS_BRANCH || 'main' }}
+          branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
           repo: bitwarden/clients
@@ -128,6 +131,7 @@ jobs:
           npm ci
 
       - name: Run all tests
+        id: playwright-tests
         run: npm run test:static:ci
 
       - name: Update job summary
@@ -144,3 +148,29 @@ jobs:
             ./test-summary
             ./tests-out/videos
             ./tests-out/screenshots
+
+      # Only post back to the PR if there was a failure since test-all has the
+      # typical config case covered for success feedback
+      - name: Communicate BIT failure on originating issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: failure() && github.event.client_payload.origin_issue
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = 'bitwarden';
+            const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
+
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with ${{ inputs.FEATURE_FLAGS === '{}' ? 'all feature flags disabled.': '\n\n<details><summary><div>The following flags enabled:</div></summary>```json\n${{inputs.FEATURE_FLAGS}}```'}
+
+            ❌ Unfortunately, one or more of these BIT tests failed. 😞
+
+            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you'd like help.
+
+            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.client_payload.origin_issue,
+              owner: owner,
+              repo: 'clients',
+              body: message
+            });

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -159,7 +159,6 @@ jobs:
           npm ci
 
       - name: Run all tests
-        id: playwright-tests
         run: npm run test:static:ci
 
       - name: Update job summary

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -29,8 +29,36 @@ jobs:
       packages: read
       pull-requests: write
     steps:
+      - name: Log in to Azure
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get Azure Key Vault secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Log out from Azure
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
+        id: app-token
+        with:
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: bitwarden
+          repositories: clients
+          permission-actions: write
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -74,7 +102,7 @@ jobs:
           branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
-          repo: jprusik/clients
+          repo: bitwarden/clients
           if_no_artifact_found: fail
           skip_unpack: true
 
@@ -155,7 +183,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: failure() && github.event.client_payload.origin_issue
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = 'bitwarden';
             const featureFlags = "${{ inputs.FEATURE_FLAGS || '{}' }}";

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -158,15 +158,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = 'bitwarden';
-            const featureFlags = ${{ inputs.FEATURE_FLAGS }};
+            const featureFlags = "${{ inputs.FEATURE_FLAGS || '{}' }}";
+            const featureFlagsMessage = featureFlags === '{}' ? 'all feature flags disabled.': `\n\n<details><summary><div>The following flags enabled:</div></summary>\`\`\`json\n${featureFlags}\`\`\``;
             const runURL = `https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}`;
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with ${ featureFlags === '{}' ? 'all feature flags disabled.': '\n\n<details><summary><div>The following flags enabled:</div></summary>\`\`\`json\n${ featureFlags }\`\`\`'}}
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with ${featureFlagsMessage}
 
             ❌ Unfortunately, one or more of these BIT tests failed. 😞
 
-            Please resolve the failure before merging- reach out to \`@bitwarden/team-autofill-dev\` if you'd like help.
+            Please resolve the failure before merging; reach out to \`@bitwarden/team-autofill-dev\` if you'd like help.
 
             You can view the detailed results of the tests [here](${runURL}).`;
 

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -28,9 +28,17 @@ jobs:
       contents: read
       packages: read
       pull-requests: write
+    outputs:
+      send_pr_feedback: false
     steps:
+      - name: Send PR feedback check
+        id: set-send-pr-feedback
+        run: |
+          echo "send_pr_feedback=github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
@@ -39,16 +47,19 @@ jobs:
       - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
 
       - name: Generate GH App token
-        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
         id: app-token
+        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
@@ -180,7 +191,7 @@ jobs:
       # typical config case covered for success feedback
       - name: Communicate BIT failure on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: failure() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
+        if: failure() && steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Communicate BIT failure on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: failure() && github.event.client_payload.origin_issue
+        if: failure() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -206,7 +206,7 @@ jobs:
 
       - name: Communicate BIT success on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: success() && github.event.client_payload.origin_issue
+        if: success() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,9 +1,11 @@
 name: Test-all
-run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
+run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH || github.event.client_payload.origin_branch }} by @${{ github.actor }}
 on:
   push:
     branches:
       - "main"
+  repository_dispatch:
+    types: [trigger-bit-tests]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -24,6 +26,7 @@ jobs:
       id-token: write
       contents: read
       packages: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,7 +68,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
           workflow_conclusion: ""
-          branch: ${{ inputs.CLIENTS_BRANCH || 'main' }}
+          branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
           repo: bitwarden/clients
@@ -130,6 +133,7 @@ jobs:
           npm ci
 
       - name: Run all tests
+        id: playwright-tests
         run: npm run test:static:ci
 
       - name: Update job summary
@@ -137,7 +141,7 @@ jobs:
         run: echo "$(<./test-summary/test-summary.md)" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload results as artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:
           name: test-summary
@@ -146,3 +150,49 @@ jobs:
             ./test-summary
             ./tests-out/videos
             ./tests-out/screenshots
+
+      - name: Communicate BIT success on originating issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: failure() && github.event.client_payload.origin_issue
+        with:
+          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          script: |
+            const owner = 'bitwarden';
+            const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
+
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
+
+            ❌ Unfortunately, one or more of the BIT tests failed. 😞
+
+            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you need help.
+
+            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.client_payload.origin_issue,
+              owner: owner,
+              repo: 'clients',
+              body: message
+            });
+
+      - name: Communicate BIT failure on originating issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: success() && github.event.client_payload.origin_issue
+        with:
+          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          script: |
+            const owner = 'bitwarden';
+            const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
+
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
+
+            ✅ Fortunately, the BIT tests have passed! 🎉
+
+            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.client_payload.origin_issue,
+              owner: owner,
+              repo: 'clients',
+              body: message
+            });

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -141,7 +141,7 @@ jobs:
         run: echo "$(<./test-summary/test-summary.md)" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload results as artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-summary
@@ -151,18 +151,18 @@ jobs:
             ./tests-out/videos
             ./tests-out/screenshots
 
-      - name: Communicate BIT success on originating issue
+      - name: Communicate BIT failure on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: failure() && github.event.client_payload.origin_issue
         with:
-          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = 'bitwarden';
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
             [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the `${{ REMOTE_VAULT_CONFIG_MATCH || 'US production'}}` server.
 
-            ❌ Unfortunately, one or more of the BIT tests failed. 😞
+            ❌ Unfortunately, one or more of these BIT tests failed. 😞
 
             Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you'd like help.
 
@@ -175,20 +175,18 @@ jobs:
               body: message
             });
 
-      - name: Communicate BIT failure on originating issue
+      - name: Communicate BIT success on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: success() && github.event.client_payload.origin_issue
         with:
-          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = 'bitwarden';
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the `${{ REMOTE_VAULT_CONFIG_MATCH || 'US production'}}` server.
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
 
-            ✅ Fortunately, these BIT tests have passed! 🎉
-
-            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+            ✅ Fortunately, [these BIT tests have passed](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId})! 🎉
 
             github.rest.issues.createComment({
               issue_number: context.payload.client_payload.origin_issue,

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -28,8 +28,36 @@ jobs:
       packages: read
       pull-requests: write
     steps:
+      - name: Log in to Azure
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get Azure Key Vault secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Log out from Azure
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
+        id: app-token
+        with:
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: bitwarden
+          repositories: clients
+          permission-actions: write
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -155,7 +183,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: failure() && github.event.client_payload.origin_issue
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = 'bitwarden';
             const runURL = `https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}`;
@@ -181,14 +209,14 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: success() && github.event.client_payload.origin_issue
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = 'bitwarden';
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
             [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
 
-            ✅ Fortunately, [these BIT tests have passed](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId})! 🎉
+            ✅ Fortunately, [these BIT tests have passed](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId})! 🎉`;
 
             github.rest.issues.createComment({
               issue_number: context.payload.client_payload.origin_issue,

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -160,11 +160,11 @@ jobs:
             const owner = 'bitwarden';
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the `${{ REMOTE_VAULT_CONFIG_MATCH || 'US production'}}` server.
 
             ❌ Unfortunately, one or more of the BIT tests failed. 😞
 
-            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you need help.
+            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you'd like help.
 
             You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
 
@@ -184,9 +184,9 @@ jobs:
             const owner = 'bitwarden';
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience.
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the `${{ REMOTE_VAULT_CONFIG_MATCH || 'US production'}}` server.
 
-            ✅ Fortunately, the BIT tests have passed! 🎉
+            ✅ Fortunately, these BIT tests have passed! 🎉
 
             You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -161,7 +161,6 @@ jobs:
           npm ci
 
       - name: Run all tests
-        id: playwright-tests
         run: npm run test:static:ci
 
       - name: Update job summary

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -158,15 +158,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = 'bitwarden';
+            const runURL = `https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}`;
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the `${{ REMOTE_VAULT_CONFIG_MATCH || 'US production'}}` server.
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the \`${{ vars.BW_REMOTE_VAULT_CONFIG_MATCH || 'US production' }}\` server.
 
             ❌ Unfortunately, one or more of these BIT tests failed. 😞
 
-            Please resolve the failure before merging; reach out to `@bitwarden/team-autofill-dev` if you'd like help.
+            Please resolve the failure before merging; reach out to \`@bitwarden/team-autofill-dev\` if you'd like help.
 
-            You can view the detailed results of the tests [here](https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}).`;
+            You can view the detailed results of the tests [here](${runURL}).`;
 
             github.rest.issues.createComment({
               issue_number: context.payload.client_payload.origin_issue,

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -159,9 +159,10 @@ jobs:
           script: |
             const owner = 'bitwarden';
             const runURL = `https://github.com/${owner}/browser-interactions-testing/actions/runs/${context.runId}`;
+            const configURL = new URL('${{ vars.BW_REMOTE_VAULT_CONFIG_MATCH }}');
             const message = `⚠️ **Files have been modified in this PR that impact the Autofill experience** ⚠️
 
-            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by the \`${{ vars.BW_REMOTE_VAULT_CONFIG_MATCH || 'US production' }}\` server.
+            [BIT](https://github.com/${owner}/browser-interactions-testing) was run to verify no regressions have been introduced to the core Autofill experience. The tests ran with the same feature flag configuration used by \`${configURL.hostname}\`
 
             ❌ Unfortunately, one or more of these BIT tests failed. 😞
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -27,9 +27,17 @@ jobs:
       contents: read
       packages: read
       pull-requests: write
+    outputs:
+      send_pr_feedback: false
     steps:
+      - name: Send PR feedback check
+        id: set-send-pr-feedback
+        run: |
+          echo "send_pr_feedback=github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
@@ -38,16 +46,19 @@ jobs:
       - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
 
       - name: Generate GH App token
-        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
         id: app-token
+        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
+        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
@@ -180,7 +191,7 @@ jobs:
 
       - name: Communicate BIT failure on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: failure() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
+        if: failure() && steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -206,7 +217,7 @@ jobs:
 
       - name: Communicate BIT success on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: success() && github.event.client_payload.origin_issue && vars.ENABLE_PR_FEEDBACK == 'true'
+        if: success() && steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |


### PR DESCRIPTION
## 🎟️ Tracking

[PM-5756](https://bitwarden.atlassian.net/browse/PM-5756)

## 📔 Objective

This adds [repository dispatch](https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch) triggers (on "trigger-bit-tests" event) to the Test-all and Test-all-custom-flags workflows. The workflows will now additionally comment with the BIT results on the originating PR.

(The [`ENABLE_PR_FEEDBACK` var can be updated](https://github.com/bitwarden/browser-interactions-testing/settings/variables/actions/ENABLE_PR_FEEDBACK) to a value other than `"true"` (or even deleted) to turn off commenting on the origin PR. )

The corresponding `clients` work: https://github.com/bitwarden/clients/pull/15960

## Testing

Permissioning and commenting tested/verified in https://github.com/bitwarden/browser-interactions-testing/pull/375; receipt verified in https://github.com/bitwarden/clients/pull/15988

## 📸 Screenshots

| **Test-all success** |
| --- |
| <img width="911" height="223" alt="Screenshot 2025-08-12 at 2 45 54 PM" src="https://github.com/user-attachments/assets/c3216f82-0100-4468-b7c2-62253f886e0d" /> |

| **Test-all failure** |
| --- |
| <img width="913" height="321" alt="Screenshot 2025-08-12 at 2 45 47 PM" src="https://github.com/user-attachments/assets/9dca2ea4-54e6-4240-a3d7-eaf38b79c052" /> |

| **Test-all-custom-flags failure** |
| --- |
| <img width="917" height="322" alt="Screenshot 2025-08-12 at 2 45 26 PM" src="https://github.com/user-attachments/assets/6cfe2fa8-3800-43b0-8f5b-a173c9bdd44e" /> |

| **Test-all-custom-flags success** |
| --- |
| This case does not send a report back to the originating PR |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-5756]: https://bitwarden.atlassian.net/browse/PM-5756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ