### PR TITLE
[PM-24622] Replace missing REMOTE_VAULT_CONFIG_MATCH in dotenv generation

### DIFF
--- a/.github/actions/setup-env-file/action.yml
+++ b/.github/actions/setup-env-file/action.yml
@@ -52,6 +52,9 @@ inputs:
   PAGES_HOST_PORT:
     description: "Port for pages host."
     required: true
+  REMOTE_VAULT_CONFIG_MATCH:
+    description: "Location of server configuration."
+    required: false
   VAULT_HOST_INSECURE_PORT:
     description: "Insecure port for vault host."
     required: true
@@ -127,6 +130,7 @@ runs:
         echo "PAGES_HOST_INSECURE_PORT=${{ inputs.PAGES_HOST_INSECURE_PORT }}" >> .env
         echo "PAGES_HOST_PORT=${{ inputs.PAGES_HOST_PORT }}" >> .env
         echo "PAGES_HOST=\"${{ inputs.PAGES_HOST }}\"" >> .env
+        echo "REMOTE_VAULT_CONFIG_MATCH=\"${{ inputs.REMOTE_VAULT_CONFIG_MATCH }}\"" >> .env
         echo "VAULT_HOST_INSECURE_PORT=${{ inputs.VAULT_HOST_INSECURE_PORT }}" >> .env
         echo "VAULT_HOST_PORT=${{ inputs.VAULT_HOST_PORT }}" >> .env
         echo "VAULT_HOST_URL=\"${{ inputs.VAULT_HOST_URL }}\"" >> .env

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -45,6 +45,7 @@ jobs:
           BW_DB_SERVER: ${{ vars.BW_DB_SERVER }}
           BW_DOMAIN: ${{ vars.BW_DOMAIN }}
           BW_ENABLE_SSL: ${{ vars.BW_ENABLE_SSL }}
+          REMOTE_VAULT_CONFIG_MATCH: ${{ inputs.REMOTE_VAULT_CONFIG_MATCH || vars.BW_REMOTE_VAULT_CONFIG_MATCH }}
           BW_SSL_CERT: ${{ vars.BW_SSL_CERT }}
           BW_SSL_KEY: ${{ vars.BW_SSL_KEY }}
           CI: true


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24622](https://bitwarden.atlassian.net/browse/PM-24622)

## 📔 Objective

We erroneously dropped this ENV variable in a recent PR; we need it back in to test against prod flags:
https://github.com/bitwarden/browser-interactions-testing/commit/3d0614e76c13cc6854a57af56a32212cff0923a8#diff-12d2c3c126fcc84106dce4b6d2be2220f018661b111a5382ad6effc1047f66aeL60

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
