### PR TITLE
[PM-24980] Send no PR feedback when clients build is missing

### DIFF
--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -105,6 +105,7 @@ jobs:
         run: echo "{\"flagValues\":${{ inputs.FEATURE_FLAGS || '{}' }}}" > flags.json
 
       - name: Download extension artifact
+        id: get-build-artifact
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,6 +117,11 @@ jobs:
           repo: bitwarden/clients
           if_no_artifact_found: fail
           skip_unpack: true
+
+      - name: Set no PR feedback when missing build artifact
+        if: ${{ failure() && steps.get-build-artifact.conclusion == 'failure' }}
+        run: |
+          echo "send_pr_feedback=false" > "$GITHUB_OUTPUT"
 
       - name: Unzip extension artifact
         run: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -102,6 +102,7 @@ jobs:
           VAULT_HOST_URL: ${{ vars.VAULT_HOST_URL }}
 
       - name: Download extension artifact
+        id: get-build-artifact
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -113,6 +114,11 @@ jobs:
           repo: bitwarden/clients
           if_no_artifact_found: fail
           skip_unpack: true
+
+      - name: Set no PR feedback when missing build artifact
+        if: ${{ failure() && steps.get-build-artifact.conclusion == 'failure' }}
+        run: |
+          echo "send_pr_feedback=false" > "$GITHUB_OUTPUT"
 
       - name: Unzip extension artifact
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24980](https://bitwarden.atlassian.net/browse/PM-24980)

## 📔 Objective

Cut down on failure notices that aren't related to BIT testing outcomes. In these cases where the clients build isn't available, it's expected to be due to a timing issue (lots of rapid commits being pushed up) or some other blocking concern that implies a re-run of BIT in the immediate/relevant future.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-24980]: https://bitwarden.atlassian.net/browse/PM-24980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ