### PR TITLE
[PM-25171] update BIT for removal of flagged notification bar logic from clients

### DIFF
--- a/tests/static/notifications.spec.ts
+++ b/tests/static/notifications.spec.ts
@@ -165,6 +165,10 @@ test.describe("Extension triggers a notification when a page form is submitted w
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
+          const saveNotificationBar = testPage.locator(
+            '[data-testid="save-notification-bar"]',
+          );
+
           const notificationCloseButtonLocator =
             notificationIframeLocator.getByRole("button", { name: "Close" });
 
@@ -172,6 +176,9 @@ test.describe("Extension triggers a notification when a page form is submitted w
             // Target the notification close button since it's present on all notification cases
             await expect(notificationCloseButtonLocator).not.toBeVisible();
           } else {
+            // Ensure the correct type of notification appears
+            await expect(saveNotificationBar).toBeVisible();
+
             // Close the notification for the next triggering case
             await notificationCloseButtonLocator.click();
 
@@ -278,15 +285,14 @@ test.describe("Extension triggers a notification when a page form is submitted w
             ),
           });
 
-          const notificationLocator = await testPage
+          const notificationLocator = testPage
             .locator("#bit-notification-bar-iframe")
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
-          const updatePasswordNotificationLocator =
-            notificationLocator.getByText(
-              "Do you want to update this password in Bitwarden?",
-            );
+          const updatePasswordNotificationLocator = testPage.locator(
+            '[data-testid="update-notification-bar"]',
+          );
 
           const notificationCloseButtonLocator = notificationLocator.getByRole(
             "button",

--- a/tests/static/notifications.spec.ts
+++ b/tests/static/notifications.spec.ts
@@ -165,14 +165,9 @@ test.describe("Extension triggers a notification when a page form is submitted w
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
-          const saveNotificationBar = notificationLocator.locator(
+          const newCipherNotificationLocator = notificationLocator.locator(
             '[data-testid="save-notification-bar"]',
           );
-
-          // @TODO feature-flagged code path via `notification-refresh`;
-          // remove dead code path with the removal of flag
-          const newCipherNotificationLocatorAlternate =
-            notificationLocator.getByText("Save login");
 
           const notificationCloseButtonLocator = notificationLocator.getByRole(
             "button",
@@ -184,12 +179,7 @@ test.describe("Extension triggers a notification when a page form is submitted w
             await expect(notificationCloseButtonLocator).not.toBeVisible();
           } else {
             // Ensure the correct type of notification appears
-            await expect(
-              newCipherNotificationLocator.or(
-                newCipherNotificationLocatorAlternate,
-              ),
-            ).toBeVisible();
-
+            await expect(newCipherNotificationLocator).toBeVisible();
 
             // Close the notification for the next triggering case
             await notificationCloseButtonLocator.click();
@@ -306,11 +296,6 @@ test.describe("Extension triggers a notification when a page form is submitted w
             '[data-testid="update-notification-bar"]',
           );
 
-          // @TODO feature-flagged code path via `notification-refresh`;
-          // remove dead code path with the removal of flag
-          const updatePasswordNotificationLocatorAlternate =
-            notificationLocator.getByText("Update existing login");
-
           const notificationCloseButtonLocator = notificationLocator.getByRole(
             "button",
             { name: "Close" },
@@ -321,11 +306,7 @@ test.describe("Extension triggers a notification when a page form is submitted w
             await expect(notificationCloseButtonLocator).not.toBeVisible();
           } else {
             // Ensure the correct type of notification appears
-            await expect(
-              updatePasswordNotificationLocator.or(
-                updatePasswordNotificationLocatorAlternate,
-              ),
-            ).toBeVisible();
+            await expect(updatePasswordNotificationLocator).toBeVisible();
 
             // Close the notification for the next triggering case
             await notificationCloseButtonLocator.click();

--- a/tests/static/notifications.spec.ts
+++ b/tests/static/notifications.spec.ts
@@ -160,17 +160,19 @@ test.describe("Extension triggers a notification when a page form is submitted w
             ),
           });
 
-          const notificationIframeLocator = testPage
+          const notificationLocator = testPage
             .locator("#bit-notification-bar-iframe")
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
-          const saveNotificationBar = testPage.locator(
+          const saveNotificationBar = notificationLocator.locator(
             '[data-testid="save-notification-bar"]',
           );
 
-          const notificationCloseButtonLocator =
-            notificationIframeLocator.getByRole("button", { name: "Close" });
+          const notificationCloseButtonLocator = notificationLocator.getByRole(
+            "button",
+            { name: "Close" },
+          );
 
           if (shouldNotTriggerNewNotification) {
             // Target the notification close button since it's present on all notification cases
@@ -290,7 +292,7 @@ test.describe("Extension triggers a notification when a page form is submitted w
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
-          const updatePasswordNotificationLocator = testPage.locator(
+          const updatePasswordNotificationLocator = notificationLocator.locator(
             '[data-testid="update-notification-bar"]',
           );
 

--- a/tests/static/notifications.spec.ts
+++ b/tests/static/notifications.spec.ts
@@ -160,27 +160,18 @@ test.describe("Extension triggers a notification when a page form is submitted w
             ),
           });
 
-          const notificationLocator = await testPage
+          const notificationIframeLocator = testPage
             .locator("#bit-notification-bar-iframe")
             .last() // @TODO `last` here shouldn't be needed; revisit after notification revisions
             .contentFrame();
 
-          const newCipherNotificationLocator = notificationLocator.getByText(
-            "Should Bitwarden remember this password for you?",
-          );
-
-          const notificationCloseButtonLocator = notificationLocator.getByRole(
-            "button",
-            { name: "Close" },
-          );
+          const notificationCloseButtonLocator =
+            notificationIframeLocator.getByRole("button", { name: "Close" });
 
           if (shouldNotTriggerNewNotification) {
             // Target the notification close button since it's present on all notification cases
             await expect(notificationCloseButtonLocator).not.toBeVisible();
           } else {
-            // Ensure the correct type of notification appears
-            await expect(newCipherNotificationLocator).toBeVisible();
-
             // Close the notification for the next triggering case
             await notificationCloseButtonLocator.click();
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-25171
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Update BIT tests to reflect new notification bar, utilized `data-testId` instead of copy to avoid potential breakage. 

>[!NOTE]
> This PR will fail because the client side logic has yet to merge until both PR's are ready to go in the below order 
>1. Update the BIT tests in a PR
>2. Get both PRs in an approved state
>3. after QA approval, merge clients changes (one BIT test should fail on the PR)
>4. Merge BIT PR and manually trigger a BIT check against clients

>[!IMPORTANT]
>Passing runs pointed at https://github.com/bitwarden/clients/pull/16113/
>Test all custom flags: https://github.com/bitwarden/browser-interactions-testing/actions/runs/17269643029
>Test all: https://github.com/bitwarden/browser-interactions-testing/actions/runs/1726942719


<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
