### PR TITLE
[PM-24980] Bugfix - Address workflows skipping the comment cleanup step

### DIFF
--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Remove past BIT status comments on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
+        if: (success() || failure()) && steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Remove past BIT status comments on originating issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
+        if: (success() || failure()) && steps.set-send-pr-feedback.outputs.send_pr_feedback == 'true'
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24980](https://bitwarden.atlassian.net/browse/PM-24980)

## 📔 Objective

Follow up from https://github.com/bitwarden/browser-interactions-testing/pull/383 - address the cleanup step being skipped on failures.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes


[PM-24980]: https://bitwarden.atlassian.net/browse/PM-24980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ