### PR TITLE
[PM-25464] Bugfix - Include targeted headers in feature flag syncing script

### DIFF
--- a/scripts/match-server-config.ts
+++ b/scripts/match-server-config.ts
@@ -29,7 +29,18 @@ async function matchRemoteFeatureFlags() {
   const { REMOTE_VAULT_CONFIG_MATCH } = process.env;
   if (REMOTE_VAULT_CONFIG_MATCH) {
     try {
-      const response = await fetch(REMOTE_VAULT_CONFIG_MATCH);
+      const options = {
+        method: "GET",
+        headers: {
+          // We need to include client headers that are targeted by our external
+          // feature flag service for conditional return values
+          "bitwarden-client-version": "2025.8.2",
+          "device-type": "2",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        },
+      };
+      const response = await fetch(REMOTE_VAULT_CONFIG_MATCH, options);
 
       const { featureStates } =
         ((await response.json()) as VaultConfigurationResponseData) || {};


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25464](https://bitwarden.atlassian.net/browse/PM-25464)

## 📔 Objective

The feature flag syncing script that fetches the US Bitwarden production server flag configuration to test against neglects to include identifying headers that are targeted by Launch Darkly and consequently return conditional values.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
