### PR TITLE
[bre-1874] switch BIT tests to workflow dispatch

### DIFF
--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -1,11 +1,9 @@
 name: Test-all-custom-flags
-run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH || github.event.client_payload.origin_branch }} by @${{ github.actor }}
+run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   push:
     branches:
       - "main"
-  repository_dispatch:
-    types: [trigger-bit-tests]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -18,6 +16,10 @@ on:
         default: "{}"
         description: 'JSON key-value pairs representing feature flag states. (e.g. {"autofill-v2": true, "autofill-overlay": false})'
         required: true
+        type: string
+      origin_issue:
+        description: "PR number in bitwarden/clients to post feedback to"
+        required: false
         type: string
 jobs:
   build-and-test:
@@ -34,7 +36,7 @@ jobs:
       - name: Send PR feedback check
         id: set-send-pr-feedback
         env:
-          _SEND_PR_FEEDBACK: ${{ (github.event.client_payload.origin_issue || false) && (vars.ENABLE_PR_FEEDBACK || false) }}
+          _SEND_PR_FEEDBACK: ${{ (inputs.origin_issue || false) && (vars.ENABLE_PR_FEEDBACK || false) }}
         run: |
           echo "send_pr_feedback=$_SEND_PR_FEEDBACK" >> "$GITHUB_OUTPUT"
 
@@ -115,7 +117,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
           workflow_conclusion: ""
-          branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
+          branch: ${{ inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
           repo: bitwarden/clients
@@ -210,7 +212,7 @@ jobs:
             const owner = 'bitwarden';
 
             const issueComments = await github.rest.issues.listComments({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
             });
@@ -267,7 +269,7 @@ jobs:
             `;
 
             github.rest.issues.createComment({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
               body: message
@@ -297,7 +299,7 @@ jobs:
             `;
 
             github.rest.issues.createComment({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
               body: message

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,11 +1,9 @@
 name: Test-all
-run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH || github.event.client_payload.origin_branch }} by @${{ github.actor }}
+run-name: All tests with extension build ${{ inputs.CLIENTS_BRANCH }} by @${{ github.actor }}
 on:
   push:
     branches:
       - "main"
-  repository_dispatch:
-    types: [trigger-bit-tests]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -16,6 +14,10 @@ on:
         type: string
       REMOTE_VAULT_CONFIG_MATCH:
         description: "URL to an endpoint returning a vault configuration (will default to US prod configuration)"
+        required: false
+        type: string
+      origin_issue:
+        description: "PR number in bitwarden/clients to post feedback to"
         required: false
         type: string
 jobs:
@@ -33,7 +35,7 @@ jobs:
       - name: Send PR feedback check
         id: set-send-pr-feedback
         env:
-          _SEND_PR_FEEDBACK: ${{ (github.event.client_payload.origin_issue || false) && (vars.ENABLE_PR_FEEDBACK || false) }}
+          _SEND_PR_FEEDBACK: ${{ (inputs.origin_issue || false) && (vars.ENABLE_PR_FEEDBACK || false) }}
         run: |
           echo "send_pr_feedback=$_SEND_PR_FEEDBACK" >> "$GITHUB_OUTPUT"
 
@@ -111,7 +113,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-browser.yml
           workflow_conclusion: ""
-          branch: ${{ github.event.client_payload.origin_branch || inputs.CLIENTS_BRANCH || 'main' }}
+          branch: ${{ inputs.CLIENTS_BRANCH || 'main' }}
           name: ^dist-chrome-MV3-\w{7}\.zip$
           name_is_regexp: true
           repo: bitwarden/clients
@@ -211,7 +213,7 @@ jobs:
             const owner = 'bitwarden';
 
             const issueComments = await github.rest.issues.listComments({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
             });
@@ -265,7 +267,7 @@ jobs:
             `;
 
             github.rest.issues.createComment({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
               body: message
@@ -292,7 +294,7 @@ jobs:
             `;
 
             github.rest.issues.createComment({
-              issue_number: context.payload.client_payload.origin_issue,
+              issue_number: Number(context.payload.inputs?.origin_issue),
               owner: owner,
               repo: 'clients',
               body: message


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1874](https://bitwarden.atlassian.net/browse/bre-1874)

## 📔 Objective
[clients repo PR](https://github.com/bitwarden/clients/pull/20469)

Replace `repository_dispatch` support with `workflow_dispatch` to support the updated trigger mechanism in `bitwarden/clients`

- Removes `repository_dispatch` trigger from `test-all.yml` and `test-all-custom-flags.yml` (clients was the only caller)
- Adds `origin_issue` as a `workflow_dispatch` input so PR feedback comments continue to work
- Simplifies all `client_payload` references to `inputs.*`