### PR TITLE
[PM-37816] Remove check for new tab

### DIFF
--- a/benchmarks/fixtures.benchmark.ts
+++ b/benchmarks/fixtures.benchmark.ts
@@ -86,7 +86,11 @@ export function createBenchmarkTest(
       await use(extensionId);
     },
     extensionSetup: async ({ context, extensionId }, use) => {
-      const testPage = await obtainTestPage(context);
+      let testPage: Page;
+
+      await test.step("Obtain the test page", async () => {
+        testPage = await obtainTestPage(context);
+      });
 
       await test.step("Configure the environment", async () => {
         if (vaultHostURL) {

--- a/benchmarks/fixtures.benchmark.ts
+++ b/benchmarks/fixtures.benchmark.ts
@@ -8,11 +8,7 @@ import {
 } from "@playwright/test";
 import { configDotenv } from "dotenv";
 
-import {
-  vaultEmail,
-  vaultPassword,
-  vaultHostURL,
-} from "../constants";
+import { vaultEmail, vaultPassword, vaultHostURL } from "../constants";
 import { PerfCapture } from "../abstractions";
 import {
   fetchFeatureFlags,
@@ -86,11 +82,7 @@ export function createBenchmarkTest(
       await use(extensionId);
     },
     extensionSetup: async ({ context, extensionId }, use) => {
-      let testPage: Page;
-
-      await test.step("Obtain the test page", async () => {
-        testPage = await obtainTestPage(context);
-      });
+      const testPage: Page = await obtainTestPage(context);
 
       await test.step("Configure the environment", async () => {
         if (vaultHostURL) {

--- a/benchmarks/fixtures.benchmark.ts
+++ b/benchmarks/fixtures.benchmark.ts
@@ -9,18 +9,17 @@ import {
 import { configDotenv } from "dotenv";
 
 import {
-  debugIsActive,
   vaultEmail,
   vaultPassword,
   vaultHostURL,
 } from "../constants";
 import { PerfCapture } from "../abstractions";
 import {
-  closeWelcomePage,
   fetchFeatureFlags,
   type FeatureFlags,
   getBackgroundPage,
   loginToVault,
+  obtainTestPage,
   prepareEnvironment,
   readManifestVersion,
   submitEnvironment,
@@ -87,16 +86,7 @@ export function createBenchmarkTest(
       await use(extensionId);
     },
     extensionSetup: async ({ context, extensionId }, use) => {
-      let testPage: Page;
-
-      await test.step("Close the extension welcome page when it pops up", async () => {
-        testPage = await closeWelcomePage(
-          context,
-          !debugIsActive &&
-            process.env.HEADLESS !== "true" &&
-            process.env.CI === "true",
-        );
-      });
+      const testPage = await obtainTestPage(context);
 
       await test.step("Configure the environment", async () => {
         if (vaultHostURL) {

--- a/fixtures/extension-setup.ts
+++ b/fixtures/extension-setup.ts
@@ -6,21 +6,12 @@ import { defaultGotoOptions, defaultWaitForOptions } from "../constants";
 
 export type FeatureFlags = { [key: string]: boolean };
 
-export async function closeWelcomePage(
-  context: BrowserContext,
-  // Wait for the extension to open the welcome page before continuing
-  // (only relevant when using prod or build artifacts in CI)
-  shouldWaitForWelcomePopup: boolean,
-): Promise<Page> {
-  if (shouldWaitForWelcomePopup) {
-    await context.waitForEvent("page");
-  }
-
-  const contextPages = await context.pages();
+export async function obtainTestPage(context: BrowserContext): Promise<Page> {
+  const contextPages = context.pages();
 
   // close all but the first tab
   await Promise.all(
-    contextPages.slice(1).map((contextPage) => contextPage.close()),
+    contextPages.slice(1).map((contextPage: Page) => contextPage.close()),
   );
 
   return contextPages[0];

--- a/fixtures/extension-setup.ts
+++ b/fixtures/extension-setup.ts
@@ -56,7 +56,7 @@ export async function prepareEnvironment(
 }
 
 export async function submitEnvironment(testPage: Page): Promise<void> {
-  await testPage.click("bit-dialog button[type='submit']");
+  await testPage.click("[bit-dialog] button[type='submit']");
 }
 
 export async function loginToVault(

--- a/tests/fixtures.browser.ts
+++ b/tests/fixtures.browser.ts
@@ -96,11 +96,7 @@ export const test = base.extend<{
     await use(extensionId);
   },
   extensionSetup: async ({ context, extensionId, testOutputPath }, use) => {
-    let testPage: Page;
-
-    await test.step("Obtain the test page", async () => {
-      testPage = await obtainTestPage(context);
-    });
+    const testPage: Page = await obtainTestPage(context);
 
     await test.step("Configure the environment", async () => {
       if (vaultHostURL) {

--- a/tests/fixtures.browser.ts
+++ b/tests/fixtures.browser.ts
@@ -96,7 +96,11 @@ export const test = base.extend<{
     await use(extensionId);
   },
   extensionSetup: async ({ context, extensionId, testOutputPath }, use) => {
-    const testPage = await obtainTestPage(context);
+    let testPage: Page;
+
+    await test.step("Obtain the test page", async () => {
+      testPage = await obtainTestPage(context);
+    });
 
     await test.step("Configure the environment", async () => {
       if (vaultHostURL) {

--- a/tests/fixtures.browser.ts
+++ b/tests/fixtures.browser.ts
@@ -10,18 +10,17 @@ import {
 import { configDotenv } from "dotenv";
 
 import {
-  debugIsActive,
   screenshotsOutput,
   vaultEmail,
   vaultPassword,
   vaultHostURL,
 } from "../constants";
 import {
-  closeWelcomePage,
   fetchFeatureFlags,
   type FeatureFlags,
   getBackgroundPage,
   loginToVault,
+  obtainTestPage,
   prepareEnvironment,
   readManifestVersion,
   submitEnvironment,
@@ -97,16 +96,7 @@ export const test = base.extend<{
     await use(extensionId);
   },
   extensionSetup: async ({ context, extensionId, testOutputPath }, use) => {
-    let testPage: Page;
-
-    await test.step("Close the extension welcome page when it pops up", async () => {
-      testPage = await closeWelcomePage(
-        context,
-        !debugIsActive &&
-          process.env.HEADLESS !== "true" &&
-          process.env.CI === "true",
-      );
-    });
+    const testPage = await obtainTestPage(context);
 
     await test.step("Configure the environment", async () => {
       if (vaultHostURL) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37816

## 📔 Objective

Removes checks for the welcome page, as that page is removed in https://github.com/bitwarden/clients/pull/20755.

The method is re-scoped to just close all other tabs and return the first one, as it would have previously if the welcome tab were disabled.