### PR TITLE
[PM-38629] Update server selection menu item for BIT configuration

### DIFF
--- a/fixtures/extension-setup.ts
+++ b/fixtures/extension-setup.ts
@@ -49,9 +49,9 @@ export async function prepareEnvironment(
   await environmentSelectorMenuButton.waitFor(defaultWaitForOptions);
   await environmentSelectorMenuButton.click();
 
-  const environmentSelectorMenu = await testPage.getByRole("menuitem", {
-    name: "self-hosted",
-  });
+  const environmentSelectorMenu = await testPage
+    .locator("#cdk-overlay-0")
+    .getByRole("button", { name: "self-hosted" });
 
   await environmentSelectorMenu.waitFor(defaultWaitForOptions);
   await environmentSelectorMenu.click();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38629](https://bitwarden.atlassian.net/browse/PM-38629)

## 📔 Objective

The reference to the environment selector menu item for “self-hosted” has changed and needs to be updated for BIT to run properly again:
https://github.com/bitwarden/browser-interactions-testing/actions/runs/27037098379/job/79803735815

[PM-38629]: https://bitwarden.atlassian.net/browse/PM-38629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ