### PR TITLE
[PM-39586] Bump self-host image version and switch to hash pinning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
   "enabledManagers": [
+    "custom.regex",
     "dockerfile",
     "docker-compose",
     "github-actions",
     "npm",
     "nvm"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)docker-compose\\.ya?ml$"],
+      "matchStrings": [
+        "image:\\s+(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)\\s+#\\s+(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ],
   "packageRules": [
     {
@@ -16,7 +27,7 @@
     },
     {
       "groupName": "docker-compose minor",
-      "matchManagers": ["docker-compose"],
+      "matchManagers": ["docker-compose", "custom.regex"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {

--- a/.github/workflows/a11y-eval-browser.yml
+++ b/.github/workflows/a11y-eval-browser.yml
@@ -90,7 +90,7 @@ jobs:
           certutil -d "sql:$HOME/.pki/nssdb" -A -t "CP,CP," -n TestAutomationSSL -i "./$BW_SSL_CERT"
 
       - name: Install Bitwarden CLI
-        run: npm install -g @bitwarden/cli@2026.4.1
+        run: npm install -g @bitwarden/cli@2026.6.0
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/a11y-eval-web.yml
+++ b/.github/workflows/a11y-eval-web.yml
@@ -68,7 +68,7 @@ jobs:
           certutil -d "sql:$HOME/.pki/nssdb" -A -t "CP,CP," -n TestAutomationSSL -i "./$BW_SSL_CERT"
 
       - name: Install Bitwarden CLI
-        run: npm install -g @bitwarden/cli@2026.4.1
+        run: npm install -g @bitwarden/cli@2026.6.0
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -144,7 +144,7 @@ jobs:
           certutil -d "sql:$HOME/.pki/nssdb" -A -t "CP,CP," -n TestAutomationSSL -i "./$BW_SSL_CERT"
 
       - name: Install Bitwarden CLI
-        run: npm install -g @bitwarden/cli@2026.4.1
+        run: npm install -g @bitwarden/cli@2026.6.0
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -146,6 +146,25 @@ jobs:
       - name: Install Bitwarden CLI
         run: npm install -g @bitwarden/cli@2026.6.0
 
+      # FIXME Temporary workaround for PM-39403: server >= 2026.6.1 returns responses
+      # that node-fetch v2 treats as a premature close (ERR_STREAM_PREMATURE_CLOSE),
+      # even though the response body is fully delivered. Neutralize the two
+      # `new Error('Premature close')` emission sites in the CLI's bundled
+      # node-fetch so seed:vault:ciphers can proceed. Remove this step once
+      # PM-39403 ships and the lite image is rebuilt with the fix.
+      - name: Patch @bitwarden/cli node-fetch (PM-39403 workaround)
+        run: |
+          NF=$(npm root -g)/@bitwarden/cli/node_modules/node-fetch/lib/index.js
+          BEFORE=$(grep -c "Premature close" "$NF" || echo 0)
+          # Each match is followed by `err.code = ...` and an emit/callback
+          # line; delete the 3-line body, leaving the surrounding `if` empty.
+          sed -i "/new Error('Premature close')/,+2d" "$NF"
+          AFTER=$(grep -c "Premature close" "$NF" || echo 0)
+          echo "node-fetch patch: removed $((BEFORE - AFTER)) of $BEFORE match(es)"
+          if [ "$AFTER" != "0" ]; then
+            echo "WARNING: not all Premature-close references removed; @bitwarden/cli's node-fetch may have changed shape"
+          fi
+
       - name: Install project dependencies
         run: |
           npm ci

--- a/.github/workflows/test-all-custom-flags.yml
+++ b/.github/workflows/test-all-custom-flags.yml
@@ -154,6 +154,16 @@ jobs:
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60
 
+      - name: Wait for admin DB migrations to complete
+        run: |
+          echo "Waiting for admin DB migrations..."
+          timeout 120 sh -c '
+            until docker compose exec -T bitwarden sh -c "grep -q \"Migration successful\" /etc/bitwarden/logs/admin-*.log 2>/dev/null"; do
+              sleep 2
+            done
+          '
+          echo "Migrations complete."
+
       - name: Generate crypto values
         run: npm run setup:crypto
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -140,7 +140,7 @@ jobs:
           certutil -d "sql:$HOME/.pki/nssdb" -A -t "CP,CP," -n TestAutomationSSL -i "./$BW_SSL_CERT"
 
       - name: Install Bitwarden CLI
-        run: npm install -g @bitwarden/cli@2026.4.1
+        run: npm install -g @bitwarden/cli@2026.6.0
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -142,6 +142,25 @@ jobs:
       - name: Install Bitwarden CLI
         run: npm install -g @bitwarden/cli@2026.6.0
 
+      # FIXME Temporary workaround for PM-39403: server >= 2026.6.1 returns responses
+      # that node-fetch v2 treats as a premature close (ERR_STREAM_PREMATURE_CLOSE),
+      # even though the response body is fully delivered. Neutralize the two
+      # `new Error('Premature close')` emission sites in the CLI's bundled
+      # node-fetch so seed:vault:ciphers can proceed. Remove this step once
+      # PM-39403 ships and the lite image is rebuilt with the fix.
+      - name: Patch @bitwarden/cli node-fetch (PM-39403 workaround)
+        run: |
+          NF=$(npm root -g)/@bitwarden/cli/node_modules/node-fetch/lib/index.js
+          BEFORE=$(grep -c "Premature close" "$NF" || echo 0)
+          # Each match is followed by `err.code = ...` and an emit/callback
+          # line; delete the 3-line body, leaving the surrounding `if` empty.
+          sed -i "/new Error('Premature close')/,+2d" "$NF"
+          AFTER=$(grep -c "Premature close" "$NF" || echo 0)
+          echo "node-fetch patch: removed $((BEFORE - AFTER)) of $BEFORE match(es)"
+          if [ "$AFTER" != "0" ]; then
+            echo "WARNING: not all Premature-close references removed; @bitwarden/cli's node-fetch may have changed shape"
+          fi
+
       - name: Install project dependencies
         run: |
           npm ci

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -155,6 +155,16 @@ jobs:
       - name: Build and start the test vault
         run: docker compose up -d --build --remove-orphans --wait --wait-timeout 60
 
+      - name: Wait for admin DB migrations to complete
+        run: |
+          echo "Waiting for admin DB migrations..."
+          timeout 120 sh -c '
+            until docker compose exec -T bitwarden sh -c "grep -q \"Migration successful\" /etc/bitwarden/logs/admin-*.log 2>/dev/null"; do
+              sleep 2
+            done
+          '
+          echo "Migrations complete."
+
       - name: Generate crypto values
         run: npm run setup:crypto
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-name: v2026-06-00
+name: v2026-06-01
 services:
   bitwarden:
     depends_on:
       - db
     env_file:
       - .env
-    image: ghcr.io/bitwarden/lite:2026.6.0
+    image: ghcr.io/bitwarden/lite:2026.6.1
     restart: "no"
     ports:
       - ${VAULT_HOST_PORT}:8443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - db
     env_file:
       - .env
-    image: ghcr.io/bitwarden/lite:2026.6.1
+    image: ghcr.io/bitwarden/lite@sha256:01181904fd02020dbc4d0598dd31a153b3784abd8a4d3ac9099fc1a939a58e6e # 2026.6.1
     restart: "no"
     ports:
       - ${VAULT_HOST_PORT}:8443
@@ -21,7 +21,7 @@ services:
       MARIADB_PASSWORD: ${BW_DB_PASSWORD}
       MARIADB_DATABASE: ${BW_DB_DATABASE}
       MARIADB_RANDOM_ROOT_PASSWORD: "true"
-    image: mariadb:12
+    image: mariadb@sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b # 12
     restart: "no"
     volumes:
       - data:/var/lib/mysql

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/chrome": "0.1.31",
         "@types/node": "24.13.2",
         "cross-env": "10.1.0",
-        "cross-fetch": "4.1.0",
         "dotenv": "17.4.1",
         "husky": "9.1.7",
         "lint-staged": "17.0.7",
@@ -362,16 +361,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -651,27 +640,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -933,13 +901,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1018,24 +979,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/chrome": "0.1.31",
     "@types/node": "24.13.2",
     "cross-env": "10.1.0",
-    "cross-fetch": "4.1.0",
     "dotenv": "17.4.1",
     "husky": "9.1.7",
     "lint-staged": "17.0.7",

--- a/scripts/create-account.ts
+++ b/scripts/create-account.ts
@@ -123,7 +123,7 @@ async function createAccount() {
       return;
     }
   } catch (error) {
-    console.log("[debug] caught:", error);
+    // Server isn't ready yet
   }
 
   console.log(`Retrying account creation at ${vaultHost}...`);

--- a/scripts/create-account.ts
+++ b/scripts/create-account.ts
@@ -1,4 +1,3 @@
-import fetch from "cross-fetch";
 import { configDotenv } from "dotenv";
 
 configDotenv({ quiet: true });
@@ -39,7 +38,7 @@ async function createAccount() {
   const vaultHost = `${VAULT_HOST_URL}:${VAULT_HOST_PORT}`;
 
   try {
-    const requestOptions = {
+    const requestOptions: RequestInit = {
       headers: {
         accept: "application/json",
         "content-type": "application/json; charset=utf-8",
@@ -124,7 +123,7 @@ async function createAccount() {
       return;
     }
   } catch (error) {
-    // Server isn't ready yet
+    console.log("[debug] caught:", error);
   }
 
   console.log(`Retrying account creation at ${vaultHost}...`);

--- a/scripts/first-time-setup.sh
+++ b/scripts/first-time-setup.sh
@@ -36,7 +36,7 @@ else
   echo "nvm not detected; skipping 'nvm install'. Ensure your active Node version matches ${projectRoot}/.nvmrc."
 fi
 
-npm install -g @bitwarden/cli@2026.4.1
+npm install -g @bitwarden/cli@2026.6.0
 
 npm ci
 npx playwright install --with-deps chromium

--- a/scripts/match-server-config.ts
+++ b/scripts/match-server-config.ts
@@ -1,4 +1,3 @@
-import fetch from "cross-fetch";
 import path from "path";
 import fs from "fs";
 import { configDotenv } from "dotenv";

--- a/scripts/vault-seeder.ts
+++ b/scripts/vault-seeder.ts
@@ -1,4 +1,3 @@
-import fetch from "cross-fetch";
 import { configDotenv } from "dotenv";
 import {
   CardItemTemplate,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39586](https://bitwarden.atlassian.net/browse/PM-39586)

## Summary

There is [a known issue with node-fetch](https://github.com/node-fetch/node-fetch/issues/1131). I fixed it in BIT's shell script for account creation by dropping cross-fetch and using the native node fetch, but the cipher seeding script still fails because it uses the CLI API, and the CLI bundles node-fetch `2.7.0` : https://github.com/bitwarden/clients/blob/main/apps/cli/package.json#L84

But, that's been pinned there for quite some time, and this bad interaction is recent. (a [self-host image rewrite](https://bitwarden.atlassian.net/browse/BRE-2049) happened some time between `Jun 25, 4:53 AM EDT` (last good BIT run with `2026.6.0` ) and `Jun 25, 5:05 AM EDT` (the first failure with this error on the rewritten `2026.6.0` image).

Because `2026.6.0` was working, and then broke when `2026.6.1` was tagged, I'm presuming the breaking change came with `2026.6.1` and not `2026.6.0`

I was able to get BIT working again by ad-hoc patching `node-fetch` bundled with the CLI in the test workflows, but local usage will continue to be bugged until addressed either by the server or CLI client

[PM-39586]: https://bitwarden.atlassian.net/browse/PM-39586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ